### PR TITLE
GitHubからインストールしたときにaws_federation_loginディレクトリのソースが含まれない問題

### DIFF
--- a/aws_federation_login/federation_url.py
+++ b/aws_federation_login/federation_url.py
@@ -156,7 +156,7 @@ def let_user_choose_config(names: t.List[str]) -> str:
 
 
 def open_link_page(
-    url: str, destination: str, template_dir: str, temphtml: tempfile._TemporaryFileWrapper[str]
+    url: str, destination: str, template_dir: str, temphtml: tempfile._TemporaryFileWrapper
 ):
     env = Environment(
         loader=FileSystemLoader(path.join(template_dir, "..", "assets/")),

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
- setup.cfgにpackages項目がなかったため追加